### PR TITLE
TEST: Listen for and emit chat msgs to all clients

### DIFF
--- a/test/chatroom.test.js
+++ b/test/chatroom.test.js
@@ -26,7 +26,7 @@ const cleanup = (io, clientSockets, done) =>
     done()
 }
 
-describe('Chatroom', () =>
+describe('Chatroom Server', () =>
 {
     describe('Connection Events', () =>
     {
@@ -124,6 +124,41 @@ describe('Chatroom', () =>
                 })
                 setTimeout(() => {
                     expect(msg).toBe(`User ID ${clientID} left`)
+                    cleanup(sio, [client, client2], done)
+                }, 300)
+            })
+        })
+
+        it('should listen for and emit chat messages back to clients', done =>
+        {
+            const server = createServer()
+            const sio = new Server(server)
+
+            server.listen(() =>
+            {
+                const client = createClient(server)
+                const client2 = createClient(server)
+                let clientID, msg = undefined
+
+                sio.on('connect', socket =>
+                {
+                    registerChatroomhandlers(sio, socket)
+
+                    client.emit('chatroom:connect')
+                    client2.on('chatroom:join', () =>
+                    {
+                        clientID = client.id
+
+                        setTimeout(() => client.emit('chatroom:chat_message', `Chat message from ${client.id}`), 50)
+                        client2.on('chatroom:chat_message', chatMsg =>
+                        {
+                            expect(chatMsg).toBeDefined()
+                            msg = chatMsg
+                        })
+                    })
+                })
+                setTimeout(() => {
+                    expect(msg).toBe(`Chat message from ${clientID}`)
                     cleanup(sio, [client, client2], done)
                 }, 300)
             })


### PR DESCRIPTION
## Summary

## Testing
**Set Jest timeout for Chat Event tests to 3s**
- Most tests should pass within 3s, but no less than 300ms, as premature failure is more likely due to slower speed of client-server handshake compared to speed of test execution

**Listen for and emit chat messages to all clients**
- Once clients connect to server and join the chatroom, they will all listen for `chatroom:chat_message` event. When clients emit this event, the server will listen and broadcast the same event and message to all clients