### PR TITLE
REF: Emit all payloads as single object

### DIFF
--- a/public/client.js
+++ b/public/client.js
@@ -29,9 +29,9 @@ nicknameForm.addEventListener('submit', e =>
     }
 })
 
-socket.on('chatroom:global_msg_sent', (sender, msg) => addChatMessage(`${sender.nickName || sender.id}: ${msg}`))
-socket.on('chatroom:join', clientID => addChatMessage(`User ID ${clientID} joined`))
-socket.on('chatroom:leave', clientID => addChatMessage(`User ID ${clientID} left`))
+socket.on('chatroom:global_msg_sent', res => addChatMessage(`${res.sender.nickName || res.sender.id}: ${res.msg}`))
+socket.on('chatroom:join', res => addChatMessage(`User ID ${res.id} joined`))
+socket.on('chatroom:leave', res => addChatMessage(`User ID ${res.id} left`))
 
 addChatMessage = msg =>
 {

--- a/src/chatroomHandler.js
+++ b/src/chatroomHandler.js
@@ -1,17 +1,17 @@
 module.exports = (io, socket) =>
 {
-    const disconnect = () => io.emit('chatroom:leave', socket.id)
-    const sendGlobalMsg = msg => io.emit('chatroom:global_msg_sent', { nickName: socket.nickName, id: socket.id }, msg)
+    const disconnect = () => io.emit('chatroom:leave', { id: socket.id })
+    const sendGlobalMsg = msg => io.emit('chatroom:global_msg_sent', { sender: { nickName: socket.nickName, id: socket.id }, msg: msg })
 
     const setNickname = name =>
     {
         socket.nickName = name
-        io.emit('chatroom:nickname_set', name)
+        io.emit('chatroom:nickname_set', { nickName: name })
     }
 
     const connect = () =>
     {
-        io.emit('chatroom:join', socket.id)
+        io.emit('chatroom:join', { id: socket.id })
 
         socket.on('disconnect', disconnect)
         socket.on('chatroom:send_global_msg', sendGlobalMsg)

--- a/test/chatroom.test.js
+++ b/test/chatroom.test.js
@@ -78,10 +78,10 @@ describe('Chatroom Server', () =>
                     client.emit('chatroom:connect')
 
                     // Client2 listens for chatroom join event, should receive ID of client that joined
-                    client2.once('chatroom:join', id =>
+                    client2.once('chatroom:join', res =>
                     {
-                        expect(id).toBeDefined()
-                        joinedClientID = id
+                        expect(res).toBeDefined()
+                        joinedClientID = res.id
                     })
                 })
                 // We need to wait for clients to finish listening to events and for
@@ -115,10 +115,10 @@ describe('Chatroom Server', () =>
                         leftClientID = client.id
 
                         setTimeout(() => client.disconnect(), 50)
-                        client2.on('chatroom:leave', id =>
+                        client2.on('chatroom:leave', res =>
                         {
-                            expect(id).toBeDefined()
-                            msg = `User ID ${id} left`
+                            expect(res).toBeDefined()
+                            msg = `User ID ${res.id} left`
                         })
                     })
                 })
@@ -145,10 +145,10 @@ describe('Chatroom Server', () =>
                     registerChatroomhandlers(sio, socket)
 
                     client.emit('chatroom:set_nickname', clientName)
-                    client.on('chatroom:nickname_set', name =>
+                    client.on('chatroom:nickname_set', res =>
                     {
-                        expect(name).toBeDefined()
-                        returnedName = name
+                        expect(res).toBeDefined()
+                        returnedName = res.nickName
                     })
                 })
                 setTimeout(() =>
@@ -180,11 +180,10 @@ describe('Chatroom Server', () =>
                         clientID = client.id
 
                         setTimeout(() => client.emit('chatroom:send_global_msg', `Chat message from ${client.id}`), 50)
-                        client2.on('chatroom:global_msg_sent', (sender, chatMsg) =>
+                        client2.on('chatroom:global_msg_sent', res =>
                         {
-                            expect(sender).toBeDefined()
-                            expect(chatMsg).toBeDefined()
-                            msg = `${sender.nickName || sender.id}: ${chatMsg}`
+                            expect(res).toBeDefined()
+                            msg = `${res.sender.nickName || res.sender.id}: ${res.msg}`
                         })
                     })
                 })


### PR DESCRIPTION
All info is stored in a single object, clients will have easier time managing the data emitted